### PR TITLE
Add go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gopackage/stats
+
+go 1.13


### PR DESCRIPTION
Add go module support following [blog post](https://blog.golang.org/migrating-to-go-modules). There does not appear to be a `go.sum` file required since there are no dependencies.

Important! You must tag the release - recommended `v0.1.0` for the tag name (semantic versioning required).